### PR TITLE
Fix: Improve plugin connectivity and add server testing docs

### DIFF
--- a/plugin/main.ts
+++ b/plugin/main.ts
@@ -182,8 +182,9 @@ export default class YamanakaPlugin extends Plugin {
     }
 
     handleFullSyncRequiredEvent(data: import('./api/client').FullSyncEventData) {
-        console.log('[Yamanaka] SSE: Received full_sync_required event:', data.message);
-        new Notice(`Yamanaka: Server requires full sync. ${data.message}. Pulling all changes...`);
+        console.log(`[Yamanaka] SSE: Received full_sync_required event: ${data.message}. Initiating pull.`);
+        // Notice removed from here, as syncManager.pull() will provide its own notices
+        // regarding the success or failure of the pull operation.
         this.syncManager.pull(); // This will pull all files
     }
 


### PR DESCRIPTION
- Plugin: Normalize server URL in ApiClient to ensure scheme (http://) is present and handle trailing slashes. This should resolve major connectivity issues where users omit the scheme.
- Plugin: Add console logging for outgoing request URLs in ApiClient.
- Plugin: Improve error message for invalid URL TypeErrors in ApiClient.
- Plugin: Remove redundant user notice in main.ts for 'full_sync_required' event as syncManager.pull provides its own feedback.
- Docs: Create Testing.md with curl commands for manual server API testing, covering push, pull, multi-device simulation, and SSE concepts.